### PR TITLE
Fix parsing for go patch version

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,16 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.x
-      - name: Static Code Analysis
-        uses: golangci/golangci-lint-action@v3
-        with:
-          args: |
-            --timeout 5m --out-${NO_FUTURE}format colored-line-number --enable errcheck,gosimple,govet,ineffassign,staticcheck,typecheck,unused,gocritic,asasalint,asciicheck,errchkjson,exportloopref,forcetypeassert,makezero,nilerr,unparam,unconvert,wastedassign,usestdlibvars
+      - name: Run golangci linter
+        uses: jfrog/.github/actions/golangci-lint@main
   Go-Sec:
     name: Go-Sec
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/gomod-absolutizer
 
-go 1.22
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/gomod-absolutizer
 
-go 1.18
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/mod/modfile"
 )
@@ -79,7 +80,8 @@ func parseGoMod(goModPath string) (result *modfile.File, errs []error) {
 		return nil, append(errs, err)
 	}
 
-	result, err = modfile.Parse(goModPath, goModContent, nil)
+	sanitized := sanitizeGoMod(goModContent)
+	result, err = modfile.Parse(goModPath, sanitized, nil)
 	if err != nil {
 		return nil, append(errs, err)
 	}
@@ -136,4 +138,21 @@ func exitIfError(err error) {
 	}
 	fmt.Println(err.Error())
 	os.Exit(1)
+}
+
+func sanitizeGoMod(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "go ") {
+			parts := strings.Fields(line)
+			if len(parts) == 2 {
+				versionParts := strings.Split(parts[1], ".")
+				if len(versionParts) >= 2 {
+					lines[i] = "go " + versionParts[0] + "." + versionParts[1]
+				}
+			}
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
 }

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -80,8 +82,8 @@ func parseGoMod(goModPath string) (result *modfile.File, errs []error) {
 		return nil, append(errs, err)
 	}
 
-	sanitized := sanitizeGoMod(goModContent)
-	result, err = modfile.Parse(goModPath, sanitized, nil)
+	sanitizedGoMod := sanitizeGoMod(goModContent)
+	result, err = modfile.Parse(goModPath, sanitizedGoMod, nil)
 	if err != nil {
 		return nil, append(errs, err)
 	}
@@ -140,19 +142,30 @@ func exitIfError(err error) {
 	os.Exit(1)
 }
 
+// This function removes the patch version of go from the go mod file as the parsing function cannot accept a patch in go version.
 func sanitizeGoMod(data []byte) []byte {
-	lines := strings.Split(string(data), "\n")
-	for i, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "go ") {
-			parts := strings.Fields(line)
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	found := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if !found && strings.HasPrefix(trimmed, "go ") {
+			parts := strings.Fields(trimmed)
 			if len(parts) == 2 {
 				versionParts := strings.Split(parts[1], ".")
 				if len(versionParts) >= 2 {
-					lines[i] = "go " + versionParts[0] + "." + versionParts[1]
+					// Rewrite the line with major.minor only
+					line = "go " + versionParts[0] + "." + versionParts[1]
+					found = true // we only sanitize the first go directive
 				}
 			}
 		}
+		out.WriteString(line)
+		out.WriteByte('\n')
 	}
-	return []byte(strings.Join(lines, "\n"))
+
+	return out.Bytes()
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/gomod-absolutizer#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixed the Parse function by sanitizing the go mod if it the go version includes a patch version, 
as the parse function from the official package of Go does not support patch versions.

Also updated the static check in workflow to be as in our other projects, as it was deprecated here.